### PR TITLE
Update to use jest's rootDir configuration

### DIFF
--- a/__tests__/run.test.js
+++ b/__tests__/run.test.js
@@ -3,13 +3,17 @@ const FlowtypeRunner = require('../src/FlowtypeRunner');
 
 const emptyCallback = () => {};
 
+const globalConfig = {
+  rootDir: process.cwd(),
+};
+
 describe('jest-runner-flow tests', () => {
   test('running on valid file', () => {
     let status = '';
     const resultHandler = (test, testResults) => {
       [{ status }] = testResults.testResults;
     };
-    const result = new FlowtypeRunner().runTests(
+    const result = new FlowtypeRunner(globalConfig).runTests(
       [{ path: path.join(__dirname, '../testFiles/valid.js') }],
       emptyCallback,
       emptyCallback,
@@ -23,7 +27,7 @@ describe('jest-runner-flow tests', () => {
     const resultHandler = (test, testResults) => {
       [{ status }] = testResults.testResults;
     };
-    const result = new FlowtypeRunner().runTests(
+    const result = new FlowtypeRunner(globalConfig).runTests(
       [{ path: path.join(__dirname, '../testFiles/invalid.js') }],
       emptyCallback,
       emptyCallback,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-runner-flowtype",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Jest runner to run flowtype checks. Fast and easy usage of jest as a platform",
   "main": "index.js",
   "readme": "./README.md",

--- a/src/FlowtypeRunner.js
+++ b/src/FlowtypeRunner.js
@@ -10,13 +10,13 @@ class FlowtypeRunner {
   runTests(tests, watcher, onStart, onResult, onFailure, options) {
     const start = +new Date();
     return new Promise((resolve) => {
-      exec('flow', { stdio: 'ignore', cwd: process.cwd() }, (err, stdout) => {
+      exec('flow', { stdio: 'ignore', cwd: this.globalConfig.rootDir }, (err, stdout) => {
         const errors = stdout.split('Error');
         const errorsPerFile = errors.reduce((previous, current) => {
           const firstErrorLine = current.split('\n')[0];
           const fileNameMatcher = firstErrorLine.match(/(\.{1,2}|\/)?([A-z]|\/|-)*\.js(x?)/);
           if (fileNameMatcher) {
-            const fileName = path.join(process.cwd(), fileNameMatcher[0]);
+            const fileName = path.join(this.globalConfig.rootDir, fileNameMatcher[0]);
             const errorMessage = current.substring(current.indexOf('\n') + 1);
             if (!previous[fileName]) {
               previous[fileName] = [];


### PR DESCRIPTION
This would close #5.

- Updates to use Jest's `rootDir` config rather than `process.cwd()` for where `flow` is run from, and for the locations of the files being tested against
- Updates tests to pass along a mocked `rootDir` config to `FlowTypeRunner`