### PR TITLE
fix windows hang

### DIFF
--- a/src/FlowtypeRunner.js
+++ b/src/FlowtypeRunner.js
@@ -17,7 +17,6 @@ class FlowtypeRunner {
           stdio: 'ignore',
           cwd: this.globalConfig.rootDir,
           env: process.env,
-          shell: true,
           windowsHide: true,
         },
         (err, stdout) => {

--- a/src/FlowtypeRunner.js
+++ b/src/FlowtypeRunner.js
@@ -13,7 +13,13 @@ class FlowtypeRunner {
     return new Promise((resolve) => {
       exec(
         'flow --color=always',
-        { stdio: 'ignore', cwd: this.globalConfig.rootDir },
+        {
+          stdio: 'ignore',
+          cwd: this.globalConfig.rootDir,
+          env: process.env,
+          shell: true,
+          windowsHide: true,
+        },
         (err, stdout) => {
           const errors = stdout.split('Error');
           const errorsPerFile = errors.reduce((previous, current) => {


### PR DESCRIPTION
This is the second attempt of fixing the windows hang, this time with 80% less git mistakes.

It runs the command in a separate shell and passes in the env. This will make `exec` use whatever shell is setup in the `%COMSPEC%` env var correctly for both the main process, and all subprocesses.

Before this, the main exec would inherit the shell it's run in, but sub-processes would default to using `cmd.exe` since the `%COMSPEC%` env var wasn't available, leading to a possible mismatch in the shells that the parent and children were using, which i'm fairly certain would cause the hang.

